### PR TITLE
Return route from paginate macro to allow chaining

### DIFF
--- a/src/PaginateRoute.php
+++ b/src/PaginateRoute.php
@@ -333,11 +333,15 @@ class PaginateRoute
         $router = $this->router;
 
         $router->macro('paginate', function ($uri, $action) use ($pageKeyword, $router) {
+            $route = null;
+
             $router->group(
                 ['middleware' => 'Spatie\PaginateRoute\SetPageMiddleware'],
-                function () use ($pageKeyword, $router, $uri, $action) {
-                    $router->get($uri.'/{pageQuery?}', $action)->where('pageQuery', $pageKeyword.'/[0-9]+');
+                function () use ($pageKeyword, $router, $uri, $action, &$route) {
+                    $route = $router->get($uri.'/{pageQuery?}', $action)->where('pageQuery', $pageKeyword.'/[0-9]+');
                 });
+
+            return $route;
         });
     }
 }


### PR DESCRIPTION
This PR adds the ability to do method chaining on the paginate route declaration e.g.
```php
Route::paginate('users', 'UsersController@index')->name('users.index');
```