### PR TITLE
FIX: Preserve query string on pagination urls. Resolves #21

### DIFF
--- a/src/PaginateRoute.php
+++ b/src/PaginateRoute.php
@@ -301,7 +301,9 @@ class PaginateRoute
             $url = str_replace(['{'.$parameterName.'}', '{'.$parameterName.'?}'], $parameterValue, $url);
         }
 
-        return $this->urlGenerator->to($url);
+        $query = \Request::getQueryString();
+
+        return $this->urlGenerator->to($url).($query ? '?'.$query : '');
     }
 
     /**

--- a/tests/PaginateRouteTest.php
+++ b/tests/PaginateRouteTest.php
@@ -182,4 +182,20 @@ class PaginateRouteTest extends TestCase
 
         $expectedForFirstPageWithClass = '<ul class="pagination"><li class="active"><a href="http://localhost/dummies">1</a></li><li><a href="http://localhost/dummies/page/2">2</a></li><li><a href="http://localhost/dummies/page/3">3</a></li><li><a href="http://localhost/dummies/page/4">4</a></li></ul>';
     }
+
+    /** @test */
+    public function it_adds_query_string_to_page_urls()
+    {
+        $this->registerDefaultRoute();
+
+        $response = $this->callRoute('/page/2', ['test' => 123]);
+
+        $this->assertTrue($response['hasNext']);
+        $this->assertEquals($this->hostName.'/dummies/page/3?test=123', $response['nextPageUrl']);
+        $this->assertTrue($response['hasPrevious']);
+        $this->assertEquals($this->hostName.'/dummies?test=123', $response['previousPageUrl']);
+
+        $fullPreviousUrl = $this->app['paginateroute']->previousPageUrl(true);
+        $this->assertEquals($this->hostName.'/dummies/page/1?test=123', $fullPreviousUrl);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -89,11 +89,12 @@ abstract class TestCase extends Orchestra
 
     /**
      * @param string $route
+     * @param array $parameters
      *
      * @return array
      */
-    protected function callRoute($route)
+    protected function callRoute($route, array $parameters = [])
     {
-        return json_decode($this->call('GET', 'dummies'.$route)->getContent(), true);
+        return json_decode($this->call('GET', 'dummies'.$route, $parameters)->getContent(), true);
     }
 }


### PR DESCRIPTION
If original request url has query parameters then these are now appended to pagination urls.

Url: `/dummy/2?some=var`
Next: `/dummy/3?some=var`
Prev: `/dummy?some=var` or` /dummy/1?some=var` if full url is requested

Test added.