### PR TITLE
Add global view variable for usage detection

### DIFF
--- a/src/SetPageMiddleware.php
+++ b/src/SetPageMiddleware.php
@@ -4,6 +4,7 @@ namespace Spatie\PaginateRoute;
 
 use Route;
 use Closure;
+use View;
 use Illuminate\Pagination\Paginator;
 
 class SetPageMiddleware
@@ -18,6 +19,8 @@ class SetPageMiddleware
         Paginator::currentPageResolver(function () {
             return app('paginateroute')->currentPage();
         });
+        
+        View::share('hasPaginateRoute', true);
 
         return $next($request);
     }


### PR DESCRIPTION
This allows detection of when a PaginateRoute is active. The main use case is probably that it allows you to make a default pagination template that can be used with default pagination as well as PaginateRoute, avoiding 404 links that would appear if you update your template but not register the route properly.

I use it like this in my default pagination template:
```html
<a  href="{{ isset($hasPaginateRoute) ? PaginateRoute::nextPageUrl($paginator) : $paginator->nextPageUrl() }}">Next page</a>
```

As the `SetPageMiddleware` is only run on routes registered with the `Route::paginate()` method, the view variable is only set when a PaginateRoute is active.